### PR TITLE
Remove try catch and add async

### DIFF
--- a/src/CurrencyNetwork.ts
+++ b/src/CurrencyNetwork.ts
@@ -33,12 +33,8 @@ export class CurrencyNetwork {
    * @returns A network object with information about name, decimals, number of users and address.
    */
   public async getInfo (networkAddress: string): Promise<NetworkDetails> {
-    try {
-      await this._checkAddresses([networkAddress])
-      return this._utils.fetchUrl<NetworkDetails>(`networks/${networkAddress}`)
-    } catch (error) {
-      return Promise.reject(error)
-    }
+    await this._checkAddresses([networkAddress])
+    return this._utils.fetchUrl<NetworkDetails>(`networks/${networkAddress}`)
   }
 
   /**
@@ -46,12 +42,8 @@ export class CurrencyNetwork {
    * @param networkAddress Address of a currency network.
    */
   public async getUsers (networkAddress: string): Promise<string[]> {
-    try {
-      await this._checkAddresses([networkAddress])
-      return this._utils.fetchUrl<string[]>(`networks/${networkAddress}/users`)
-    } catch (error) {
-      return Promise.reject(error)
-    }
+    await this._checkAddresses([networkAddress])
+    return this._utils.fetchUrl<string[]>(`networks/${networkAddress}/users`)
   }
 
   /**
@@ -63,21 +55,17 @@ export class CurrencyNetwork {
     networkAddress: string,
     userAddress: string
   ): Promise<UserOverview> {
-    try {
-      await this._checkAddresses([networkAddress, userAddress])
-      const [ overview, decimals ] = await Promise.all([
-        this._utils.fetchUrl<UserOverviewRaw>(`networks/${networkAddress}/users/${userAddress}`),
-        this.getDecimals(networkAddress)
-      ])
-      return {
-        balance: this._utils.formatAmount(overview.balance, decimals),
-        given: this._utils.formatAmount(overview.given, decimals),
-        received: this._utils.formatAmount(overview.received, decimals),
-        leftGiven: this._utils.formatAmount(overview.leftGiven, decimals),
-        leftReceived: this._utils.formatAmount(overview.leftReceived, decimals)
-      }
-    } catch (error) {
-      return Promise.reject(error)
+    await this._checkAddresses([networkAddress, userAddress])
+    const [ overview, decimals ] = await Promise.all([
+      this._utils.fetchUrl<UserOverviewRaw>(`networks/${networkAddress}/users/${userAddress}`),
+      this.getDecimals(networkAddress)
+    ])
+    return {
+      balance: this._utils.formatAmount(overview.balance, decimals),
+      given: this._utils.formatAmount(overview.given, decimals),
+      received: this._utils.formatAmount(overview.received, decimals),
+      leftGiven: this._utils.formatAmount(overview.leftGiven, decimals),
+      leftReceived: this._utils.formatAmount(overview.leftReceived, decimals)
     }
   }
 
@@ -87,25 +75,21 @@ export class CurrencyNetwork {
    * @param decimals If decimals are known they can be provided manually.
    */
   public async getDecimals (networkAddress: string, decimals?: number): Promise<number> {
-    try {
-      await this._checkAddresses([networkAddress])
-      const isNetwork = await this.isNetwork(networkAddress)
-      if (isNetwork) {
-        return Promise.resolve(
-          ((typeof decimals === 'number') && decimals) ||
-          // TODO replace with list of known currency network in clientlib
-          this._utils.fetchUrl<NetworkDetails>(`networks/${networkAddress}`)
-            .then(network => network.decimals)
-        )
+    await this._checkAddresses([networkAddress])
+    const isNetwork = await this.isNetwork(networkAddress)
+    if (isNetwork) {
+      return Promise.resolve(
+        ((typeof decimals === 'number') && decimals) ||
+        // TODO replace with list of known currency network in clientlib
+        this._utils.fetchUrl<NetworkDetails>(`networks/${networkAddress}`)
+          .then(network => network.decimals)
+      )
+    } else {
+      if ((typeof decimals === 'number') && decimals) {
+        return decimals
       } else {
-        if ((typeof decimals === 'number') && decimals) {
-          return decimals
-        } else {
-          return Promise.reject(`${networkAddress} is a token address. Decimals have to be explicit.`)
-        }
+        return Promise.reject(`${networkAddress} is a token address. Decimals have to be explicit.`)
       }
-    } catch (error) {
-      return Promise.reject(error)
     }
   }
 
@@ -114,27 +98,23 @@ export class CurrencyNetwork {
    * @param contractAddress Address which should be checked.
    */
   public async isNetwork (contractAddress: string): Promise<boolean> {
-    try {
-      await this._checkAddresses([contractAddress])
-      // TODO find another to check if given address is a currency network
-      const currencyNetworks = await this.getAll()
-      const networkAddresses = currencyNetworks.map(c => ethUtils.toChecksumAddress(c.address))
-      return networkAddresses.indexOf(ethUtils.toChecksumAddress(contractAddress)) !== -1
-    } catch (error) {
-      return Promise.reject(error)
-    }
+    await this._checkAddresses([contractAddress])
+    // TODO find another to check if given address is a currency network
+    const currencyNetworks = await this.getAll()
+    const networkAddresses = currencyNetworks.map(c => ethUtils.toChecksumAddress(c.address))
+    return networkAddresses.indexOf(ethUtils.toChecksumAddress(contractAddress)) !== -1
   }
 
   /**
    * Checks if given addresses are valid ethereum addresses.
    * @param addresses Array of addresses that should be checked.
    */
-  private _checkAddresses (addresses: string[]): Promise<boolean> {
+  private async _checkAddresses (addresses: string[]): Promise<boolean> {
     for (let address of addresses) {
       if (!this._utils.checkAddress(address)) {
-        return Promise.reject(`${address} is not a valid address.`)
+        throw new Error(`${address} is not a valid address.`)
       }
     }
-    return Promise.resolve(true)
+    return
   }
 }

--- a/src/Event.ts
+++ b/src/Event.ts
@@ -54,18 +54,14 @@ export class Event {
     networkAddress: string,
     filter: EventFilterOptions = {}
   ): Promise<TLEvent[]> {
-    try {
-      const { _currencyNetwork, _user, _utils } = this
-      const baseUrl = `networks/${networkAddress}/users/${_user.address}/events`
-      const parameterUrl = _utils.buildUrl(baseUrl, filter)
-      const [ events, decimals ] = await Promise.all([
-        _utils.fetchUrl<TLEvent[]>(parameterUrl),
-        _currencyNetwork.getDecimals(networkAddress)
-      ])
-      return events.map(event => _utils.formatEvent(event, decimals))
-    } catch (error) {
-      return Promise.reject(error)
-    }
+    const { _currencyNetwork, _user, _utils } = this
+    const baseUrl = `networks/${networkAddress}/users/${_user.address}/events`
+    const parameterUrl = _utils.buildUrl(baseUrl, filter)
+    const [ events, decimals ] = await Promise.all([
+      _utils.fetchUrl<TLEvent[]>(parameterUrl),
+      _currencyNetwork.getDecimals(networkAddress)
+    ])
+    return events.map(event => _utils.formatEvent(event, decimals))
   }
 
   /**
@@ -73,20 +69,16 @@ export class Event {
    * @param filter Event filter object. See `EventFilterOptions` for more information.
    */
   public async getAll (filter: EventFilterOptions = {}): Promise<TLEvent[]> {
-    try {
-      const { _currencyNetwork, _user, _utils } = this
-      const baseUrl = `users/${_user.address}/events`
-      const parameterUrl = _utils.buildUrl(baseUrl, filter)
-      const events = await _utils.fetchUrl<TLEvent[]>(parameterUrl)
-      const networks = this._getUniqueNetworksFromEvents(events)
-      const decimalsMap = await this._getDecimalsMap(networks)
-      return events.map(event => _utils.formatEvent(
-        event,
-        decimalsMap[event.networkAddress]
-      ))
-    } catch (error) {
-      return Promise.reject(error)
-    }
+    const { _currencyNetwork, _user, _utils } = this
+    const baseUrl = `users/${_user.address}/events`
+    const parameterUrl = _utils.buildUrl(baseUrl, filter)
+    const events = await _utils.fetchUrl<TLEvent[]>(parameterUrl)
+    const networks = this._getUniqueNetworksFromEvents(events)
+    const decimalsMap = await this._getDecimalsMap(networks)
+    return events.map(event => _utils.formatEvent(
+      event,
+      decimalsMap[event.networkAddress]
+    ))
   }
 
   /**

--- a/src/Payment.ts
+++ b/src/Payment.ts
@@ -81,7 +81,7 @@ export class Payment {
       )
       return { rawTx, path, maxFees, ethFees }
     } else {
-      return Promise.reject('Could not find a path with enough capacity.')
+      throw new Error('Could not find a path with enough capacity.')
     }
   }
 
@@ -182,14 +182,12 @@ export class Payment {
    * @param amount Requested transfer amount.
    * @param subject Additional information for payment request.
    */
-  public createRequest (
+  public async createRequest (
     networkAddress: string,
     amount: number,
     subject: string
   ): Promise<string> {
-    return new Promise(resolve => {
-      const params = [ 'paymentrequest', networkAddress, this._user.address, amount, subject ]
-      resolve(this._utils.createLink(params))
-    })
+    const params = [ 'paymentrequest', networkAddress, this._user.address, amount, subject ]
+    return this._utils.createLink(params)
   }
 }

--- a/src/Payment.ts
+++ b/src/Payment.ts
@@ -57,35 +57,31 @@ export class Payment {
     value: number | string,
     options: PaymentOptions = {}
   ): Promise<TLTxObject> {
-    try {
-      const { _user, _currencyNetwork, _transaction, _utils } = this
-      let { decimals } = options
-      decimals = await _currencyNetwork.getDecimals(network, decimals)
-      const { path, maxFees, estimatedGas } = await this.getPath(
-        network,
+    const { _user, _currencyNetwork, _transaction, _utils } = this
+    let { decimals } = options
+    decimals = await _currencyNetwork.getDecimals(network, decimals)
+    const { path, maxFees, estimatedGas } = await this.getPath(
+      network,
+      _user.address,
+      to,
+      value,
+      { ...options, decimals }
+    )
+    if (path.length > 0) {
+      const { rawTx, ethFees } = await _transaction.prepFuncTx(
         _user.address,
-        to,
-        value,
-        { ...options, decimals }
+        network,
+        'CurrencyNetwork',
+        'transfer',
+        [ to, _utils.calcRaw(value, decimals), maxFees.raw, path.slice(1) ],
+        {
+          gasPrice: options.gasPrice,
+          gasLimit: options.gasLimit || estimatedGas * 1.5
+        }
       )
-      if (path.length > 0) {
-        const { rawTx, ethFees } = await _transaction.prepFuncTx(
-          _user.address,
-          network,
-          'CurrencyNetwork',
-          'transfer',
-          [ to, _utils.calcRaw(value, decimals), maxFees.raw, path.slice(1) ],
-          {
-            gasPrice: options.gasPrice,
-            gasLimit: options.gasLimit || estimatedGas * 1.5
-          }
-        )
-        return { rawTx, path, maxFees, ethFees }
-      } else {
-        return Promise.reject('Could not find a path with enough capacity.')
-      }
-    } catch (error) {
-      return Promise.reject(error)
+      return { rawTx, path, maxFees, ethFees }
+    } else {
+      return Promise.reject('Could not find a path with enough capacity.')
     }
   }
 
@@ -129,34 +125,30 @@ export class Payment {
     value: number | string,
     options: PaymentOptions = {}
   ): Promise<PathObject> {
-    try {
-      const { _currencyNetwork, _utils, _user } = this
-      let { decimals, maximumHops, maximumFees} = options
-      decimals = await _currencyNetwork.getDecimals(network, decimals)
-      const data = {
-        from: senderAddress,
-        to: receiverAddress,
-        value: this._utils.calcRaw(value, decimals)
-      }
-      if (maximumFees) {
-        data['maxFees'] = maximumFees
-      }
-      if (maximumHops) {
-        data['maxHops'] = maximumHops
-      }
-      const endpoint = `networks/${network}/path-info`
-      const { estimatedGas, fees, path } = await _utils.fetchUrl<PathRaw>(endpoint, {
-        method: 'POST',
-        headers: new Headers({ 'Content-Type': 'application/json' }),
-        body: JSON.stringify(data)
-      })
-      return {
-        estimatedGas,
-        path,
-        maxFees: _utils.formatAmount(fees, decimals)
-      }
-    } catch (error) {
-      return Promise.reject(error)
+    const { _currencyNetwork, _utils, _user } = this
+    let { decimals, maximumHops, maximumFees} = options
+    decimals = await _currencyNetwork.getDecimals(network, decimals)
+    const data = {
+      from: senderAddress,
+      to: receiverAddress,
+      value: this._utils.calcRaw(value, decimals)
+    }
+    if (maximumFees) {
+      data['maxFees'] = maximumFees
+    }
+    if (maximumHops) {
+      data['maxHops'] = maximumHops
+    }
+    const endpoint = `networks/${network}/path-info`
+    const { estimatedGas, fees, path } = await _utils.fetchUrl<PathRaw>(endpoint, {
+      method: 'POST',
+      headers: new Headers({ 'Content-Type': 'application/json' }),
+      body: JSON.stringify(data)
+    })
+    return {
+      estimatedGas,
+      path,
+      maxFees: _utils.formatAmount(fees, decimals)
     }
   }
 
@@ -180,12 +172,8 @@ export class Payment {
    * @param rawTx RLP encoded hex string defining the transaction.
    */
   public async confirm (rawTx): Promise<string> {
-    try {
-      const signedTx = await this._user.signTx(rawTx)
-      return this._transaction.relayTx(signedTx)
-    } catch (error) {
-      return Promise.reject(error)
-    }
+    const signedTx = await this._user.signTx(rawTx)
+    return this._transaction.relayTx(signedTx)
   }
 
   /**

--- a/src/Transaction.ts
+++ b/src/Transaction.ts
@@ -74,23 +74,19 @@ export class Transaction {
     rawValue: string,
     options: TxOptions = {}
   ): Promise<TxObject> {
-    try {
-      const txInfos = await this._getTxInfos(from)
-      const txOptions = {
-        gasPrice: options.gasPrice || txInfos.gasPrice,
-        gasLimit: options.gasLimit || 21000,
-        value: new BigNumber(rawValue).toNumber(),
-        nonce: txInfos.nonce,
-        to: to.toLowerCase()
-      }
-      return {
-        rawTx: lightwallet.txutils.valueTx(txOptions),
-        ethFees: this._utils.formatAmount(
-          txOptions.gasLimit * txOptions.gasPrice, 18
-        )
-      }
-    } catch (error) {
-      this._handleError(error)
+    const txInfos = await this._getTxInfos(from)
+    const txOptions = {
+      gasPrice: options.gasPrice || txInfos.gasPrice,
+      gasLimit: options.gasLimit || 21000,
+      value: new BigNumber(rawValue).toNumber(),
+      nonce: txInfos.nonce,
+      to: to.toLowerCase()
+    }
+    return {
+      rawTx: lightwallet.txutils.valueTx(txOptions),
+      ethFees: this._utils.formatAmount(
+        txOptions.gasLimit * txOptions.gasPrice, 18
+      )
     }
   }
 

--- a/src/Transaction.ts
+++ b/src/Transaction.ts
@@ -40,25 +40,21 @@ export class Transaction {
     parameters: any[],
     options: TxOptions = {}
   ): Promise<TxObject> {
-    try {
-      const txInfos = await this._getTxInfos(userAddress)
-      const txOptions = {
-        gasPrice: options.gasPrice || txInfos.gasPrice,
-        gasLimit: options.gasLimit || 600000,
-        value: 0,
-        nonce: txInfos.nonce,
-        to: contractAddress.toLowerCase()
-      }
-      return {
-        rawTx: lightwallet.txutils.functionTx(
-          CONTRACTS[ contractName ].abi, functionName, parameters, txOptions
-        ),
-        ethFees: this._utils.formatAmount(
-          txOptions.gasLimit * txOptions.gasPrice, 18
-        )
-      }
-    } catch (error) {
-      this._handleError(error)
+    const txInfos = await this._getTxInfos(userAddress)
+    const txOptions = {
+      gasPrice: options.gasPrice || txInfos.gasPrice,
+      gasLimit: options.gasLimit || 600000,
+      value: 0,
+      nonce: txInfos.nonce,
+      to: contractAddress.toLowerCase()
+    }
+    return {
+      rawTx: lightwallet.txutils.functionTx(
+        CONTRACTS[ contractName ].abi, functionName, parameters, txOptions
+      ),
+      ethFees: this._utils.formatAmount(
+        txOptions.gasLimit * txOptions.gasPrice, 18
+      )
     }
   }
 
@@ -127,13 +123,5 @@ export class Transaction {
    */
   private _getTxInfos (userAddress: string): Promise<TxInfos> {
     return this._utils.fetchUrl<TxInfos>(`users/${userAddress}/txinfos`)
-  }
-
-  /**
-   * Reject Promise and return error message if exists.
-   * @param error error object
-   */
-  private _handleError (error: any) {
-    return Promise.reject(error.json().message || error)
   }
 }

--- a/src/Trustline.ts
+++ b/src/Trustline.ts
@@ -58,21 +58,17 @@ export class Trustline {
     received: number | string,
     options: TLOptions = {}
   ): Promise<TxObject> {
-    try {
-      const { _currencyNetwork, _transaction, _user, _utils } = this
-      let { decimals, gasLimit, gasPrice } = options
-      decimals = await _currencyNetwork.getDecimals(network, decimals)
-      return _transaction.prepFuncTx(
-        _user.address,
-        network,
-        'CurrencyNetwork',
-        'updateTrustline',
-        [ counterparty, _utils.calcRaw(given, decimals), _utils.calcRaw(received, decimals) ],
-        { gasPrice, gasLimit }
-      )
-    } catch (error) {
-      return Promise.reject(error)
-    }
+    const { _currencyNetwork, _transaction, _user, _utils } = this
+    let { decimals, gasLimit, gasPrice } = options
+    decimals = await _currencyNetwork.getDecimals(network, decimals)
+    return _transaction.prepFuncTx(
+      _user.address,
+      network,
+      'CurrencyNetwork',
+      'updateTrustline',
+      [ counterparty, _utils.calcRaw(given, decimals), _utils.calcRaw(received, decimals) ],
+      { gasPrice, gasLimit }
+    )
   }
 
   /**
@@ -111,12 +107,8 @@ export class Trustline {
    * @param rawTx RLP encoded hex string defining the transaction.
    */
   public async confirm (rawTx: string): Promise<string> {
-    try {
-      const signedTx = await this._user.signTx(rawTx)
-      return this._transaction.relayTx(signedTx)
-    } catch (error) {
-      return Promise.reject(error)
-    }
+    const signedTx = await this._user.signTx(rawTx)
+    return this._transaction.relayTx(signedTx)
   }
 
   /**
@@ -124,17 +116,13 @@ export class Trustline {
    * @param network Address of a currency network.
    */
   public async getAll (network: string): Promise<TrustlineObject[]> {
-    try {
-      const { _user, _utils, _currencyNetwork } = this
-      const endpoint = `networks/${network}/users/${_user.address}/trustlines`
-      const [ trustlines, decimals ] = await Promise.all([
-        _utils.fetchUrl<TrustlineRaw[]>(endpoint),
-        _currencyNetwork.getDecimals(network)
-      ])
-      return trustlines.map(trustline => this._formatTrustline(trustline, decimals))
-    } catch (error) {
-      return Promise.reject(error)
-    }
+    const { _user, _utils, _currencyNetwork } = this
+    const endpoint = `networks/${network}/users/${_user.address}/trustlines`
+    const [ trustlines, decimals ] = await Promise.all([
+      _utils.fetchUrl<TrustlineRaw[]>(endpoint),
+      _currencyNetwork.getDecimals(network)
+    ])
+    return trustlines.map(trustline => this._formatTrustline(trustline, decimals))
   }
 
   /**
@@ -143,17 +131,13 @@ export class Trustline {
    * @param counterparty Address of counterparty of trustline.
    */
   public async get (network: string, counterparty: string): Promise<TrustlineObject> {
-    try {
-      const { _user, _utils, _currencyNetwork } = this
-      const endpoint = `networks/${network}/users/${_user.address}/trustlines/${counterparty}`
-      const [ trustline, decimals ] = await Promise.all([
-        _utils.fetchUrl<TrustlineRaw>(endpoint),
-        _currencyNetwork.getDecimals(network)
-      ])
-      return this._formatTrustline(trustline, decimals)
-    } catch (error) {
-      return Promise.reject(error)
-    }
+    const { _user, _utils, _currencyNetwork } = this
+    const endpoint = `networks/${network}/users/${_user.address}/trustlines/${counterparty}`
+    const [ trustline, decimals ] = await Promise.all([
+      _utils.fetchUrl<TrustlineRaw>(endpoint),
+      _currencyNetwork.getDecimals(network)
+    ])
+    return this._formatTrustline(trustline, decimals)
   }
 
   /**

--- a/src/User.ts
+++ b/src/User.ts
@@ -143,7 +143,7 @@ export class User {
     serializedKeystore: string
   ): Promise<string> {
     const { address, pubKey } = await this.load(serializedKeystore)
-    const params = [ 'onboardingrequest', username, this.address, this.pubKey ]
+    const params = [ 'onboardingrequest', username, address, pubKey ]
     return this._utils.createLink(params)
   }
 
@@ -289,7 +289,7 @@ export class User {
    * Contains username and address.
    * @param username Custom username.
    */
-  public createLink (username: string): string {
+  public async createLink (username: string): Promise<string> {
     const params = ['contact', this.address, username]
     return this._utils.createLink(params)
   }

--- a/src/User.ts
+++ b/src/User.ts
@@ -45,19 +45,15 @@ export class User {
    * Loads new user into the state and returns the created user object.
    */
   public async create (): Promise<UserObject> {
-    try {
-      // generate new keystore
-      const { address, keystore, pubKey } = await this._generateKeys()
-      this.address = address
-      this.keystore = keystore
-      this.pubKey = pubKey
-      return {
-        address: this.address,
-        keystore: this.keystore.serialize(),
-        pubKey: this.pubKey
-      }
-    } catch (error) {
-      return Promise.reject(error)
+    // generate new keystore
+    const { address, keystore, pubKey } = await this._generateKeys()
+    this.address = address
+    this.keystore = keystore
+    this.pubKey = pubKey
+    return {
+      address: this.address,
+      keystore: this.keystore.serialize(),
+      pubKey: this.pubKey
     }
   }
 
@@ -67,24 +63,20 @@ export class User {
    * @param serializedKeystore Serialized [eth-lightwallet](https://github.com/ConsenSys/eth-lightwallet) key store.
    */
   public async load (serializedKeystore: string): Promise<UserObject> {
-    try {
-      const parsedKeystore = JSON.parse(serializedKeystore)
-      // check if keystore version is old and update to new version
-      if (parsedKeystore.version < 3) {
-        serializedKeystore = await this._updateKeystore(parsedKeystore)
-      }
-      const deserialized = lightwallet.keystore.deserialize(serializedKeystore)
-      const { address, keystore, pubKey } = await this._getUserObject(deserialized)
-      this.address = address
-      this.keystore = keystore
-      this.pubKey = pubKey
-      return {
-        address: this.address,
-        keystore: this.keystore.serialize(),
-        pubKey: this.pubKey
-      }
-    } catch (error) {
-      return Promise.reject(error)
+    const parsedKeystore = JSON.parse(serializedKeystore)
+    // check if keystore version is old and update to new version
+    if (parsedKeystore.version < 3) {
+      serializedKeystore = await this._updateKeystore(parsedKeystore)
+    }
+    const deserialized = lightwallet.keystore.deserialize(serializedKeystore)
+    const { address, keystore, pubKey } = await this._getUserObject(deserialized)
+    this.address = address
+    this.keystore = keystore
+    this.pubKey = pubKey
+    return {
+      address: this.address,
+      keystore: this.keystore.serialize(),
+      pubKey: this.pubKey
     }
   }
 
@@ -150,13 +142,9 @@ export class User {
     username: string,
     serializedKeystore: string
   ): Promise<string> {
-    try {
-      const { address, pubKey } = await this.load(serializedKeystore)
-      const params = [ 'onboardingrequest', username, this.address, this.pubKey ]
-      return this._utils.createLink(params)
-    } catch (error) {
-      return Promise.reject(error)
-    }
+    const { address, pubKey } = await this.load(serializedKeystore)
+    const params = [ 'onboardingrequest', username, this.address, this.pubKey ]
+    return this._utils.createLink(params)
   }
 
   /**
@@ -181,26 +169,18 @@ export class User {
    * @param rawTx RLP encoded hex string of the ethereum transaction returned by `prepOnboarding`.
    */
   public async confirmOnboarding (rawTx: string): Promise<string> {
-    try {
-      const signedTx = await this.signTx(rawTx)
-      return this._transaction.relayTx(signedTx)
-    } catch (error) {
-      return Promise.reject(error)
-    }
+    const signedTx = await this.signTx(rawTx)
+    return this._transaction.relayTx(signedTx)
   }
 
   /**
    * Returns ETH balance of loaded user.
    */
   public async getBalance (): Promise<Amount> {
-    try {
-      const balance = await this._utils.fetchUrl<string>(`users/${this.address}/balance`)
-      return this._utils.formatAmount(
-        this._utils.calcRaw(balance, 18), 18
-      )
-    } catch (error) {
-      return Promise.reject(error)
-    }
+    const balance = await this._utils.fetchUrl<string>(`users/${this.address}/balance`)
+    return this._utils.formatAmount(
+      this._utils.calcRaw(balance, 18), 18
+    )
   }
 
   /**
@@ -293,18 +273,14 @@ export class User {
    * @param seed 12 word seed phrase string.
    */
   public async recoverFromSeed (seed: string): Promise<UserObject> {
-    try {
-      const { address, keystore, pubKey } = await this._generateKeys(seed)
-      this.address = address
-      this.keystore = keystore
-      this.pubKey = pubKey
-      return {
-        address: this.address,
-        keystore: this.keystore.serialize(),
-        pubKey: this.pubKey
-      }
-    } catch (error) {
-      return Promise.reject(error)
+    const { address, keystore, pubKey } = await this._generateKeys(seed)
+    this.address = address
+    this.keystore = keystore
+    this.pubKey = pubKey
+    return {
+      address: this.address,
+      keystore: this.keystore.serialize(),
+      pubKey: this.pubKey
     }
   }
 

--- a/src/Utils.ts
+++ b/src/Utils.ts
@@ -46,17 +46,12 @@ export class Utils {
    */
   public async fetchUrl<T> (endpoint: string, options?: object): Promise<T> {
     const fullUrl = `${this._apiUrl}${endpoint}`
-    try {
-      const response = await fetch(fullUrl, options)
-      const json = await response.json()
-      if (response.status !== 200) {
-        throw new Error(`Status ${response.status} -> ${json.message}`)
-      } else {
-        return json
-      }
-    } catch (error) {
-      const errMsg = `Error fetching ${fullUrl} | ${error && error.message}`
-      return Promise.reject(new Error(errMsg))
+    const response = await fetch(fullUrl, options)
+    const json = await response.json()
+    if (response.status !== 200) {
+      throw new Error(`${fullUrl} | Status ${response.status} | ${json.message}`)
+    } else {
+      return json
     }
   }
 

--- a/tests/unit/User.test.ts
+++ b/tests/unit/User.test.ts
@@ -36,8 +36,8 @@ describe('unit', () => {
     })
 
     describe('#createLink()', () => {
-      it('should create a contact link', () => {
-        const link = tl1.user.createLink('testuser')
+      it('should create a contact link', async () => {
+        const link = await tl1.user.createLink('testuser')
         const splitLink = link.split('/')
         expect(splitLink[0]).to.equal('http:') // base url
         expect(splitLink[2]).to.equal('trustlines.network') // base url


### PR DESCRIPTION
Closes #85 and closes #86 

- Removes unnecessary `try/catch` blocks
- Adds `async` to functions which were missed in the last refactoring
- Reintroduces `async createLink`

Note: In `User.ts` there are still a lot of functions which use `new Promise...`. They are necessary though because we need to wrap the callback based functions of `eth-lightwallet` to use them as promises.