### PR TITLE
Fix Get Payment Test

### DIFF
--- a/src/Payment.ts
+++ b/src/Payment.ts
@@ -152,7 +152,7 @@ export class Payment {
     const data = {
       from: senderAddress,
       to: receiverAddress,
-      value: this._utils.calcRaw(value, decimals)
+      value: this._utils.calcRaw(value, decimals).toString()
     }
     if (maximumFees) {
       data['maxFees'] = maximumFees

--- a/tests/e2e/Payment.test.ts
+++ b/tests/e2e/Payment.test.ts
@@ -70,7 +70,9 @@ describe('e2e', () => {
     describe('#confirm()', () => {
       it('should confirm trustline transfer', async () => {
         const { rawTx } = await tl1.payment.prepare(network.address, user2.address, 1)
-        expect(tl1.payment.confirm(rawTx)).to.eventually.be.a('string')
+        const txId = await tl1.payment.confirm(rawTx)
+        await wait()
+        expect(txId).to.be.a('string')
       })
     })
 


### PR DESCRIPTION
Sometimes the e2e test for `Payment` -> `#get()` failed. This should fix it. Problem was that the test right before didn't `wait()` which lead to a wrong nonce in the following test.