### PR TITLE
Remove npm publish on develop without tags

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,14 +26,6 @@ jobs:
           email: dongha.kim210@gmail.com
           api_key:
           - secure: UJCuatBn0Oencga2bUrtMkqZlCWtGyDPSOX+3hRcraWZ/k45Us3sWxpn0ttCOOrIjTlqkCVGD0od5CKNRNgQXeAsXqw6RgIYCKXiQCWubHqOdiUoJq3oPxp98wgTx2wZRkurJeSdk4dpWYZVJB4whGjitpjBGd3/HbirBU4j2m5jBWJCjTHeA0RA7QOTUk7KzNa9AgNoWM8sQuu9FbfRkmDv1YF6cWSFHyjSp9E/qU9nP82oA65tVasBdwSxEHHcTjry8YXKqhfMkieKOhGmyRwxI4HpEp57iW+4bfruFuBosNWkx9neNGuGHn9jxXxKKjk475GFSRzV2tF1uwYBY0cNDD98kxbwqmdmxyLskejCzEKhal61qrgeQNCcnBGwvtMYoptBJVtCt32/KvE8v4TdjQBRKsCXmmemN6mczttP6LAALDpOm+UkU+qBRUcxf4kRWkvkSOlBp5Q68Awv1tcPERsoYVo9wrCX29zOcn1Ngl0eVvfoV2djmXKAkIR6KGBvg3K3sD+K8qgTE2oXXX3SHGfzGQieTlgR8uJD9Y/ZrwCYXOEc+sWdLlXotk2UpgKPz3llSyVYV1pnwe7OURbsYxXR7Mr7CaUExUs8KQjMNpbGlW70+UOW0HOsYm/T+pNklfpNNnRPTKDuN0oTFqUN584vwYe52KcF/Z90jEA=
-          tag: next
-          on:
-            branch: develop
-        - provider: npm
-          skip_cleanup: true
-          email: dongha.kim210@gmail.com
-          api_key:
-          - secure: UJCuatBn0Oencga2bUrtMkqZlCWtGyDPSOX+3hRcraWZ/k45Us3sWxpn0ttCOOrIjTlqkCVGD0od5CKNRNgQXeAsXqw6RgIYCKXiQCWubHqOdiUoJq3oPxp98wgTx2wZRkurJeSdk4dpWYZVJB4whGjitpjBGd3/HbirBU4j2m5jBWJCjTHeA0RA7QOTUk7KzNa9AgNoWM8sQuu9FbfRkmDv1YF6cWSFHyjSp9E/qU9nP82oA65tVasBdwSxEHHcTjry8YXKqhfMkieKOhGmyRwxI4HpEp57iW+4bfruFuBosNWkx9neNGuGHn9jxXxKKjk475GFSRzV2tF1uwYBY0cNDD98kxbwqmdmxyLskejCzEKhal61qrgeQNCcnBGwvtMYoptBJVtCt32/KvE8v4TdjQBRKsCXmmemN6mczttP6LAALDpOm+UkU+qBRUcxf4kRWkvkSOlBp5Q68Awv1tcPERsoYVo9wrCX29zOcn1Ngl0eVvfoV2djmXKAkIR6KGBvg3K3sD+K8qgTE2oXXX3SHGfzGQieTlgR8uJD9Y/ZrwCYXOEc+sWdLlXotk2UpgKPz3llSyVYV1pnwe7OURbsYxXR7Mr7CaUExUs8KQjMNpbGlW70+UOW0HOsYm/T+pNklfpNNnRPTKDuN0oTFqUN584vwYe52KcF/Z90jEA=
           on:
             tags: true
             branch: develop


### PR DESCRIPTION
I had to change the release/versioning flow a bit because there are some problems with the npm dist-tag `next` which we wanted to use for the latest commit on the `develop` branch. npm does not allow to update a already published version. So in order to have the latest develop branch with the tag `next` we would have to increment the version in the package.json somehow.

For a quick fix I would just manually bump the version via `npm version major | minor | patch` for official releases and only have the dist-tag `latest` as introduced in this PR.

Need some input on this @jensneuber and @berndbohmeier. Especially from you Jens as you were the one who wanted the `next` tag.