### PR TITLE
enable parity jsonrpc api

### DIFF
--- a/tests/testrelay/parity/Dockerfile
+++ b/tests/testrelay/parity/Dockerfile
@@ -5,4 +5,4 @@ COPY blockchain /blockchain
 
 EXPOSE 8545
 
-CMD ["--jsonrpc-cors", "*", "--jsonrpc-apis", "web3,eth,personal", "--jsonrpc-hosts=all", "--no-ui", "--datadir", "/blockchain/", "--config", "dev", "--unlock", "0x00a329c0648769a73afac7f9381e08fb43dbea72", "--password=/pw", "--jsonrpc-interface", "0.0.0.0"]
+CMD ["--jsonrpc-cors", "*", "--jsonrpc-apis", "web3,eth,personal,parity", "--jsonrpc-hosts=all", "--no-ui", "--datadir", "/blockchain/", "--config", "dev", "--unlock", "0x00a329c0648769a73afac7f9381e08fb43dbea72", "--password=/pw", "--jsonrpc-interface", "0.0.0.0"]


### PR DESCRIPTION
The relay server now tries to query the nonce using the parity jsonrpc api. This
has to be enabled via a command line option.

see https://github.com/trustlines-network/relay/commit/8550d692fac045e5ebe80eb4c9e60d26c37edf41