### PR TITLE
Fix/end2end

### DIFF
--- a/tests/e2e/Event.test.ts
+++ b/tests/e2e/Event.test.ts
@@ -157,7 +157,7 @@ describe('e2e', () => {
           ({ transactionId }) => transactionId === updateTxId
         )
         // check event TrustlineUpdateRequest
-        expect(updateRequestEvents).to.have.length(1)
+        expect(updateRequestEvents, 'Trustline Update Request should exist').to.have.length(1)
         expect(updateRequestEvents[0].type).to.equal('TrustlineUpdateRequest')
         expect(updateRequestEvents[0].timestamp).to.be.a('number')
         expect(updateRequestEvents[0].blockNumber).to.be.a('number')
@@ -180,7 +180,7 @@ describe('e2e', () => {
           ({ transactionId }) => transactionId === acceptTxId
         )
         // check event TrustlineUpdate
-        expect(updateEvents).to.have.length(1)
+        expect(updateEvents, 'Trustline Update should exist').to.have.length(1)
         expect(updateEvents[0].type).to.equal('TrustlineUpdate')
         expect(updateEvents[0].timestamp).to.be.a('number')
         expect(updateEvents[0].blockNumber).to.be.a('number')
@@ -203,7 +203,7 @@ describe('e2e', () => {
           ({ transactionId }) => transactionId === tlTransferTxId
         )
         // check event Trustlines Transfer
-        expect(tlTransferEvents).to.have.length(1)
+        expect(tlTransferEvents, 'Trustline Transfer should exist').to.have.length(1)
         expect(tlTransferEvents[0].type).to.equal('Transfer')
         expect(tlTransferEvents[0].timestamp).to.be.a('number')
         expect(tlTransferEvents[0].blockNumber).to.be.a('number')
@@ -224,7 +224,7 @@ describe('e2e', () => {
           ({ transactionId }) => transactionId === depositTxId
         )
         // check event Deposit
-        expect(depositEvents).to.have.length(1)
+        expect(depositEvents, 'Deposit should exist').to.have.length(1)
         expect(depositEvents[0].type).to.equal('Deposit')
         expect(depositEvents[0].timestamp).to.be.a('number')
         expect(depositEvents[0].blockNumber).to.be.a('number')
@@ -244,7 +244,7 @@ describe('e2e', () => {
           ({ transactionId }) => transactionId === withdrawTxId
         )
         // check event Withdraw
-        expect(withdrawEvents).to.have.length(1)
+        expect(withdrawEvents, 'Withdraw should exist').to.have.length(1)
         expect(withdrawEvents[0].type).to.equal('Withdrawal')
         expect(withdrawEvents[0].timestamp).to.be.a('number')
         expect(withdrawEvents[0].blockNumber).to.be.a('number')
@@ -264,7 +264,7 @@ describe('e2e', () => {
           ({ transactionId, type }) => transactionId === transferTxId && type === 'Transfer'
         )
         // check event Wrapped ETH Transfer
-        expect(wethTransferEvents).to.have.length(1)
+        expect(wethTransferEvents, 'ETH Transfer should exist').to.have.length(1)
         expect(wethTransferEvents[0].type).to.equal('Transfer')
         expect(wethTransferEvents[0].timestamp).to.be.a('number')
         expect(wethTransferEvents[0].blockNumber).to.be.a('number')
@@ -285,7 +285,7 @@ describe('e2e', () => {
           ({ transactionId, type }) => transactionId === fillTxId && type === 'LogFill'
         )
         // check event LogFill
-        expect(fillEvents).to.have.length(1)
+        expect(fillEvents, 'Log Fill should exist').to.have.length(1)
         expect(fillEvents[0].type).to.equal('LogFill')
         expect(fillEvents[0].timestamp).to.be.a('number')
         expect(fillEvents[0].blockNumber).to.be.a('number')
@@ -311,7 +311,7 @@ describe('e2e', () => {
           ({ transactionId, type }) => transactionId === cancelTxId && type === 'LogCancel'
         )
         // check event LogCancel
-        expect(cancelEvents).to.have.length(1)
+        expect(cancelEvents, 'Log Cancel should exist').to.have.length(1)
         expect(cancelEvents[0].type).to.equal('LogCancel')
         expect(cancelEvents[0].timestamp).to.be.a('number')
         expect(cancelEvents[0].blockNumber).to.be.a('number')

--- a/tests/e2e/Trustline.test.ts
+++ b/tests/e2e/Trustline.test.ts
@@ -167,9 +167,9 @@ describe('e2e', () => {
     })
 
     describe('#get()', () => {
-      it('should return trustline', () => {
-        expect(tl1.trustline.get(network.address, user2.address))
-          .to.eventually.have.keys('address', 'balance', 'given', 'id', 'leftGiven', 'leftReceived', 'received')
+      it('should return trustline', async () => {
+        const trustline = await tl1.trustline.get(network.address, user2.address)
+        expect(trustline).to.have.keys('counterParty', 'user', 'address', 'balance', 'given', 'id', 'leftGiven', 'leftReceived', 'received')
       })
     })
 

--- a/tests/testrelay/docker-compose.yml
+++ b/tests/testrelay/docker-compose.yml
@@ -4,7 +4,7 @@ services:
     image: trustlines/relay
     container_name: relay
     environment:
-      - TRUSTLINE_SYNC_TX_RELAY=1
+      - TRUSTLINES_SYNC_TX_RELAY=1
       - PGHOST
       - PGUSER
       - PGDATABASE

--- a/tests/testrelay/docker-compose.yml
+++ b/tests/testrelay/docker-compose.yml
@@ -20,6 +20,8 @@ services:
     networks:
       - internal
     restart: unless-stopped
+    entrypoint: ""
+    command: bash -c "sleep 7; exec tl-relay"
 
   index:
     image: trustlines/py-eth-index

--- a/tests/testrelay/docker-compose.yml
+++ b/tests/testrelay/docker-compose.yml
@@ -4,8 +4,7 @@ services:
     image: trustlines/relay
     container_name: relay
     environment:
-      - ETHINDEX=1
-      - TRUSTLINES_END2END=1
+      - TRUSTLINE_SYNC_TX_RELAY=1
       - PGHOST
       - PGUSER
       - PGDATABASE

--- a/tests/testrelay/docker-compose.yml
+++ b/tests/testrelay/docker-compose.yml
@@ -5,6 +5,7 @@ services:
     container_name: relay
     environment:
       - ETHINDEX=1
+      - TRUSTLINES_END2END=1
       - PGHOST
       - PGUSER
       - PGDATABASE

--- a/tests/testrelay/parity/Dockerfile
+++ b/tests/testrelay/parity/Dockerfile
@@ -5,4 +5,4 @@ COPY blockchain /blockchain
 
 EXPOSE 8545
 
-CMD ["--jsonrpc-cors", "*", "--jsonrpc-apis", "web3,eth,personal", "--jsonrpc-hosts=all", "--no-ui", "--datadir", "/blockchain/", "--config", "dev", "--unlock", "0x00a329c0648769a73afac7f9381e08fb43dbea72", "--password=/pw", "--jsonrpc-interface", "0.0.0.0"]
+CMD ["--jsonrpc-cors", "*", "--jsonrpc-apis", "web3,eth,personal,parity", "--jsonrpc-hosts=all", "--no-ui", "--datadir", "/blockchain/", "--config", "dev", "--unlock", "0x00a329c0648769a73afac7f9381e08fb43dbea72", "--password=/pw", "--jsonrpc-interface", "0.0.0.0"]

--- a/tests/testrelay/parity/Dockerfile
+++ b/tests/testrelay/parity/Dockerfile
@@ -1,4 +1,4 @@
-FROM parity/parity:beta
+FROM parity/parity:stable
 
 COPY pw /
 COPY blockchain /data

--- a/tests/testrelay/parity/Dockerfile
+++ b/tests/testrelay/parity/Dockerfile
@@ -1,8 +1,8 @@
 FROM parity/parity:beta
 
 COPY pw /
-COPY blockchain /blockchain
+COPY blockchain /data
 
 EXPOSE 8545
 
-CMD ["--jsonrpc-cors", "*", "--jsonrpc-apis", "web3,eth,personal,parity", "--jsonrpc-hosts=all", "--no-ui", "--datadir", "/blockchain/", "--config", "dev", "--unlock", "0x00a329c0648769a73afac7f9381e08fb43dbea72", "--password=/pw", "--jsonrpc-interface", "0.0.0.0"]
+CMD ["--jsonrpc-cors", "*", "--jsonrpc-apis", "web3,eth,personal,parity", "--jsonrpc-hosts=all", "--base-path=/data/", "--config", "dev", "--unlock", "0x00a329c0648769a73afac7f9381e08fb43dbea72", "--password=/pw", "--jsonrpc-interface", "0.0.0.0"]


### PR DESCRIPTION
This makes running the end2end tests possible again. See https://github.com/trustlines-network/relay/pull/204
