### PR TITLE
Fix parity dockerfile to work with new parity version

### DIFF
--- a/tests/testrelay/parity/Dockerfile
+++ b/tests/testrelay/parity/Dockerfile
@@ -9,5 +9,5 @@ COPY --chown=parity blockchain /home/parity/chaindata
 
 EXPOSE 8545
 
-ENTRYPOINT ["./entrypoint.sh"]
+ENTRYPOINT ["/entrypoint.sh"]
 


### PR DESCRIPTION
Location of `entrypoint.sh` changed with new parity version 2.1.7