### PR TITLE
adapt end2end tests to 'no fee for last hop' changes

### DIFF
--- a/tests/e2e/Payment.test.ts
+++ b/tests/e2e/Payment.test.ts
@@ -48,7 +48,6 @@ describe('e2e', () => {
           1.5
         )
         expect(pathObj.maxFees).to.have.keys('decimals', 'raw', 'value')
-        expect(pathObj.maxFees.raw).to.not.equal('0')
         expect(pathObj.path).to.not.equal([])
       })
 


### PR DESCRIPTION
The fees for the last hop are now zero.

This makes the end2end test run with the fix/adapt-to-contracts-0.4 relay server branch