### PR TITLE
Increase unit test coverage for class Configuration

### DIFF
--- a/src/Configuration.ts
+++ b/src/Configuration.ts
@@ -45,6 +45,18 @@ export class Configuration {
     port: number | string,
     path: string
   ): string {
-    return `${protocol}://${host}${port && `:${port}`}${path && `/${path}`}`
+    return `${protocol}://${host}${port && `:${port}`}${path &&
+      `/${this._trimUrl(path)}`}`
+  }
+
+  /**
+   * Trims url from slashes.
+   * @param url URL to be trimmed from slashes.
+   */
+  private _trimUrl(url: string): string {
+    return url
+      .split('/')
+      .filter(split => split)
+      .join('/')
   }
 }

--- a/src/Configuration.ts
+++ b/src/Configuration.ts
@@ -45,6 +45,6 @@ export class Configuration {
     port: number | string,
     path: string
   ): string {
-    return `${protocol}://${host}${port === '' ? '' : `:${port}`}/${path}`
+    return `${protocol}://${host}${port && `:${port}`}${path && `/${path}`}`
   }
 }

--- a/tests/unit/Configuration.test.ts
+++ b/tests/unit/Configuration.test.ts
@@ -1,0 +1,34 @@
+import { assert } from 'chai'
+import 'mocha'
+
+import { Configuration } from '../../src/Configuration'
+
+describe('unit', () => {
+  describe('Configuration', () => {
+    const DEFAULT_API_URL = 'http://localhost'
+    const DEFAULT_WS_API_URL = 'ws://localhost'
+
+    describe('#constructor()', () => {
+      it('should set default configuration', () => {
+        const { apiUrl, wsApiUrl, web3Provider } = new Configuration()
+        assert.equal(apiUrl, DEFAULT_API_URL)
+        assert.equal(wsApiUrl, DEFAULT_WS_API_URL)
+        assert.notOk(web3Provider)
+      })
+
+      it('should set specified configuration', () => {
+        const { apiUrl, wsApiUrl, web3Provider } = new Configuration({
+          host: 'testhost',
+          path: 'api',
+          port: 8080,
+          protocol: 'https',
+          web3Provider: 'ws://rpchost:8546',
+          wsProtocol: 'ws'
+        })
+        assert.equal(apiUrl, 'https://testhost:8080/api')
+        assert.equal(wsApiUrl, 'ws://testhost:8080/api')
+        assert.equal(web3Provider, 'ws://rpchost:8546')
+      })
+    })
+  })
+})

--- a/tests/unit/Configuration.test.ts
+++ b/tests/unit/Configuration.test.ts
@@ -16,10 +16,24 @@ describe('unit', () => {
         assert.notOk(web3Provider)
       })
 
-      it('should set specified configuration', () => {
+      it('should set correct path for multiple ending slashes', () => {
         const { apiUrl, wsApiUrl, web3Provider } = new Configuration({
           host: 'testhost',
-          path: 'api',
+          path: 'api/////',
+          port: 8080,
+          protocol: 'https',
+          web3Provider: 'ws://rpchost:8546',
+          wsProtocol: 'ws'
+        })
+        assert.equal(apiUrl, 'https://testhost:8080/api')
+        assert.equal(wsApiUrl, 'ws://testhost:8080/api')
+        assert.equal(web3Provider, 'ws://rpchost:8546')
+      })
+
+      it('should set correct path for multiple starting slashes', () => {
+        const { apiUrl, wsApiUrl, web3Provider } = new Configuration({
+          host: 'testhost',
+          path: '/////api',
           port: 8080,
           protocol: 'https',
           web3Provider: 'ws://rpchost:8546',

--- a/tests/unit/Configuration.test.ts
+++ b/tests/unit/Configuration.test.ts
@@ -29,6 +29,20 @@ describe('unit', () => {
         assert.equal(wsApiUrl, 'ws://testhost:8080/api')
         assert.equal(web3Provider, 'ws://rpchost:8546')
       })
+
+      it('should set specified configuration with trimmed path', () => {
+        const { apiUrl, wsApiUrl, web3Provider } = new Configuration({
+          host: 'testhost.com',
+          path: '///api/v1/////',
+          port: 8080,
+          protocol: 'https',
+          web3Provider: 'ws://rpchost:8546',
+          wsProtocol: 'ws'
+        })
+        assert.equal(apiUrl, 'https://testhost.com:8080/api/v1')
+        assert.equal(wsApiUrl, 'ws://testhost.com:8080/api/v1')
+        assert.equal(web3Provider, 'ws://rpchost:8546')
+      })
     })
   })
 })

--- a/tests/unit/TLNetwork.test.ts
+++ b/tests/unit/TLNetwork.test.ts
@@ -9,7 +9,7 @@ describe('unit', () => {
       it('should load default configuration', () => {
         const tlNetwork = new TLNetwork()
         expect(tlNetwork).to.be.an('object')
-        expect(tlNetwork.configuration.apiUrl).to.equal('http://localhost/')
+        expect(tlNetwork.configuration.apiUrl).to.equal('http://localhost')
       })
 
       it('should load custom configuration', () => {
@@ -21,7 +21,7 @@ describe('unit', () => {
         })
         expect(tlNetwork).to.be.an('object')
         expect(tlNetwork.configuration.apiUrl).to.equal(
-          'https://192.168.0.59:5000/api/v1/'
+          'https://192.168.0.59:5000/api/v1'
         )
       })
     })


### PR DESCRIPTION
Add unit tests for the class `Configuration`. Also includes a small fix for `configuration.apiUrl`. The URL was created with an ending `/` which is removed in this PR.