### PR TITLE
Increase unit test coverage for Configuration and Utils

### DIFF
--- a/package.json
+++ b/package.json
@@ -61,6 +61,7 @@
     "chai-as-promised": "^7.1.1",
     "codecov": "^3.1.0",
     "es6-promise": "^4.1.1",
+    "fetch-mock": "^7.2.5",
     "fluid-publish": "^2.2.0",
     "husky": "^1.1.4",
     "isomorphic-fetch": "^2.2.1",

--- a/src/Configuration.ts
+++ b/src/Configuration.ts
@@ -45,6 +45,18 @@ export class Configuration {
     port: number | string,
     path: string
   ): string {
-    return `${protocol}://${host}${port && `:${port}`}${path && `/${path}`}`
+    return `${protocol}://${host}${port && `:${port}`}${path &&
+      `/${this._trimUrl(path)}`}`
+  }
+
+  /**
+   * Trims url from slashes.
+   * @param url URL to be trimmed from slashes.
+   */
+  private _trimUrl(url: string): string {
+    return url
+      .split('/')
+      .filter(split => split)
+      .join('/')
   }
 }

--- a/src/Configuration.ts
+++ b/src/Configuration.ts
@@ -45,6 +45,6 @@ export class Configuration {
     port: number | string,
     path: string
   ): string {
-    return `${protocol}://${host}${port === '' ? '' : `:${port}`}/${path}`
+    return `${protocol}://${host}${port && `:${port}`}${path && `/${path}`}`
   }
 }

--- a/src/Utils.ts
+++ b/src/Utils.ts
@@ -48,7 +48,7 @@ export class Utils {
    * @param options (optional)
    */
   public async fetchUrl<T>(endpoint: string, options?: object): Promise<T> {
-    const fullUrl = `${this.apiUrl}${endpoint}`
+    const fullUrl = `${this.apiUrl}${this._formatEndpoint(endpoint)}`
     const response = await fetch(fullUrl, options)
     const json = await response.json()
     if (response.status !== 200) {
@@ -60,6 +60,12 @@ export class Utils {
     }
   }
 
+  /**
+   * Returns an Observable for a websocket stream.
+   * @param endpoint Endpoint to open websocket stream to,
+   * @param functionName Name of function to call on opened websocket.
+   * @param args Arguments for above function.
+   */
   public websocketStream(
     endpoint: string,
     functionName: string,
@@ -68,7 +74,7 @@ export class Utils {
     return Observable.create((observer: Observer<any>) => {
       const options = { constructor: WebSocket }
       const ws = new ReconnectingWebSocket(
-        `${this.wsApiUrl}${endpoint}`,
+        `${this.wsApiUrl}${this._formatEndpoint(endpoint)}`,
         undefined,
         options
       )
@@ -328,5 +334,16 @@ export class Utils {
     return BigNumber.random(decimals + 1)
       .multipliedBy(new BigNumber(10).pow(decimals))
       .integerValue()
+  }
+
+  /**
+   * Adds a slash to the endpoint if it does not start with it.
+   * @param endpoint Endpoint to format.
+   */
+  private _formatEndpoint(endpoint: string): string {
+    if (endpoint[0] !== '/') {
+      return `/${endpoint}`
+    }
+    return endpoint
   }
 }

--- a/src/Utils.ts
+++ b/src/Utils.ts
@@ -320,6 +320,10 @@ export class Utils {
     return ethUtils.addHexPrefix(hexStr)
   }
 
+  /**
+   * Generates a random number with specified decimals.
+   * @param decimals Decimals which determine size of generated number.
+   */
   public generateRandomNumber(decimals: number): BigNumber {
     return BigNumber.random(decimals + 1)
       .multipliedBy(new BigNumber(10).pow(decimals))

--- a/tests/unit/Configuration.test.ts
+++ b/tests/unit/Configuration.test.ts
@@ -1,0 +1,34 @@
+import { assert } from 'chai'
+import 'mocha'
+
+import { Configuration } from '../../src/Configuration'
+
+describe('unit', () => {
+  describe('Configuration', () => {
+    const DEFAULT_API_URL = 'http://localhost'
+    const DEFAULT_WS_API_URL = 'ws://localhost'
+
+    describe('#constructor()', () => {
+      it('should set default configuration', () => {
+        const { apiUrl, wsApiUrl, web3Provider } = new Configuration()
+        assert.equal(apiUrl, DEFAULT_API_URL)
+        assert.equal(wsApiUrl, DEFAULT_WS_API_URL)
+        assert.notOk(web3Provider)
+      })
+
+      it('should set specified configuration', () => {
+        const { apiUrl, wsApiUrl, web3Provider } = new Configuration({
+          host: 'testhost',
+          path: 'api',
+          port: 8080,
+          protocol: 'https',
+          web3Provider: 'ws://rpchost:8546',
+          wsProtocol: 'ws'
+        })
+        assert.equal(apiUrl, 'https://testhost:8080/api')
+        assert.equal(wsApiUrl, 'ws://testhost:8080/api')
+        assert.equal(web3Provider, 'ws://rpchost:8546')
+      })
+    })
+  })
+})

--- a/tests/unit/Configuration.test.ts
+++ b/tests/unit/Configuration.test.ts
@@ -16,10 +16,24 @@ describe('unit', () => {
         assert.notOk(web3Provider)
       })
 
-      it('should set specified configuration', () => {
+      it('should set correct path for multiple ending slashes', () => {
         const { apiUrl, wsApiUrl, web3Provider } = new Configuration({
           host: 'testhost',
-          path: 'api',
+          path: 'api/////',
+          port: 8080,
+          protocol: 'https',
+          web3Provider: 'ws://rpchost:8546',
+          wsProtocol: 'ws'
+        })
+        assert.equal(apiUrl, 'https://testhost:8080/api')
+        assert.equal(wsApiUrl, 'ws://testhost:8080/api')
+        assert.equal(web3Provider, 'ws://rpchost:8546')
+      })
+
+      it('should set correct path for multiple starting slashes', () => {
+        const { apiUrl, wsApiUrl, web3Provider } = new Configuration({
+          host: 'testhost',
+          path: '/////api',
           port: 8080,
           protocol: 'https',
           web3Provider: 'ws://rpchost:8546',

--- a/tests/unit/Configuration.test.ts
+++ b/tests/unit/Configuration.test.ts
@@ -29,6 +29,20 @@ describe('unit', () => {
         assert.equal(wsApiUrl, 'ws://testhost:8080/api')
         assert.equal(web3Provider, 'ws://rpchost:8546')
       })
+
+      it('should set specified configuration with trimmed path', () => {
+        const { apiUrl, wsApiUrl, web3Provider } = new Configuration({
+          host: 'testhost.com',
+          path: '///api/v1/////',
+          port: 8080,
+          protocol: 'https',
+          web3Provider: 'ws://rpchost:8546',
+          wsProtocol: 'ws'
+        })
+        assert.equal(apiUrl, 'https://testhost.com:8080/api/v1')
+        assert.equal(wsApiUrl, 'ws://testhost.com:8080/api/v1')
+        assert.equal(web3Provider, 'ws://rpchost:8546')
+      })
     })
   })
 })

--- a/tests/unit/LightwalletSigner.test.ts
+++ b/tests/unit/LightwalletSigner.test.ts
@@ -1,5 +1,6 @@
 import { BigNumber } from 'bignumber.js'
-import { assert } from 'chai'
+import * as chai from 'chai'
+import * as chaiAsPromised from 'chai-as-promised'
 import 'mocha'
 
 import { LightwalletSigner } from '../../src/signers/LightwalletSigner'
@@ -8,6 +9,9 @@ import { FakeEthLightwallet } from '../helpers/FakeEthLightwallet'
 import { FakeUtils } from '../helpers/FakeUtils'
 
 import { keystore1, keystore2, user1 } from '../Fixtures'
+
+chai.use(chaiAsPromised)
+const { assert } = chai
 
 describe('unit', () => {
   describe('LightwalletSigner', () => {

--- a/tests/unit/TLNetwork.test.ts
+++ b/tests/unit/TLNetwork.test.ts
@@ -15,7 +15,7 @@ describe('unit', () => {
       it('should load custom configuration', () => {
         const tlNetwork = new TLNetwork({
           host: '192.168.0.59',
-          path: 'api/v1/',
+          path: 'api/v1',
           port: 5000,
           protocol: 'https'
         })

--- a/tests/unit/TLNetwork.test.ts
+++ b/tests/unit/TLNetwork.test.ts
@@ -9,7 +9,7 @@ describe('unit', () => {
       it('should load default configuration', () => {
         const tlNetwork = new TLNetwork()
         expect(tlNetwork).to.be.an('object')
-        expect(tlNetwork.configuration.apiUrl).to.equal('http://localhost/')
+        expect(tlNetwork.configuration.apiUrl).to.equal('http://localhost')
       })
 
       it('should load custom configuration', () => {
@@ -21,7 +21,7 @@ describe('unit', () => {
         })
         expect(tlNetwork).to.be.an('object')
         expect(tlNetwork.configuration.apiUrl).to.equal(
-          'https://192.168.0.59:5000/api/v1/'
+          'https://192.168.0.59:5000/api/v1'
         )
       })
     })

--- a/tests/unit/Utils.test.ts
+++ b/tests/unit/Utils.test.ts
@@ -1,10 +1,14 @@
 import BigNumber from 'bignumber.js'
-import { assert } from 'chai'
+import * as chai from 'chai'
+import * as chaiAsPromised from 'chai-as-promised'
 import fetchMock = require('fetch-mock')
 import 'mocha'
 
 import { Utils } from '../../src/Utils'
 import { FakeConfiguration } from '../helpers/FakeConfiguration'
+
+chai.use(chaiAsPromised)
+const { assert } = chai
 
 describe('unit', () => {
   describe('Utils', () => {
@@ -412,7 +416,6 @@ describe('unit', () => {
         const randomNumber = utils.generateRandomNumber(2)
         assert.instanceOf(randomNumber, BigNumber)
         assert.isAtMost(randomNumber.toNumber(), 99)
-        assert.isAtLeast(randomNumber.toNumber(), 10)
       })
     })
   })

--- a/tests/unit/Utils.test.ts
+++ b/tests/unit/Utils.test.ts
@@ -1,150 +1,64 @@
 import BigNumber from 'bignumber.js'
-import * as chai from 'chai'
+import { assert } from 'chai'
+import fetchMock = require('fetch-mock')
 import 'mocha'
 
-import { TLNetwork } from '../../src/TLNetwork'
-import { config } from '../Fixtures'
+import { Utils } from '../../src/Utils'
+import { FakeConfiguration } from '../helpers/FakeConfiguration'
 
 describe('unit', () => {
   describe('Utils', () => {
-    const { expect } = chai
-    const tl = new TLNetwork(config)
+    // mocks
+    let fakeConfiguration
 
-    const numValue = 123
-    const strValue = numValue.toString()
-    const bnValue = new BigNumber(numValue)
-    const decimals = 2
+    // constants for number related tests
+    const VALUE_NUM_INPUT = 1.23
+    const VALUE_STR_INPUT = VALUE_NUM_INPUT.toString()
+    const VALUE_BN_INPUT = new BigNumber(VALUE_NUM_INPUT)
+    const RAW_NUM_INPUT = 123
+    const RAW_STR_INPUT = RAW_NUM_INPUT.toString()
+    const RAW_BN_INPUT = new BigNumber(RAW_NUM_INPUT)
+    const DECIMALS = 2
+    const RAW_OUTPUT = '123'
+    const VALUE_OUTPUT = '1.23'
 
-    describe('#calcRaw()', () => {
-      it('should return raw value for number', () => {
-        const raw = tl.utils.calcRaw(numValue, 2)
-        expect(raw).to.be.instanceof(BigNumber)
-        expect(raw.toString()).to.equal('12300')
+    // test object
+    let utils
+
+    describe('#fetchUrl()', () => {
+      beforeEach(() => {
+        fakeConfiguration = new FakeConfiguration()
+        utils = new Utils(fakeConfiguration)
+      })
+      afterEach(() => fetchMock.reset())
+
+      it('should return 200 json response', async () => {
+        const fakeResponse = { hello: 'world' }
+
+        // mock OK response
+        fetchMock.get('*', fakeResponse)
+
+        const jsonResponse = await utils.fetchUrl('fake/endpoint')
+        assert.deepEqual(jsonResponse, fakeResponse)
       })
 
-      it('should return raw value for string', () => {
-        const raw = tl.utils.calcRaw(strValue, 2)
-        expect(raw).to.be.instanceof(BigNumber)
-        expect(raw.toString()).to.equal('12300')
-      })
+      it('should throw error', async () => {
+        // mock ERROR response
+        fetchMock.get('*', 400)
 
-      it('should return raw value for BigNumber', () => {
-        const raw = tl.utils.calcRaw(bnValue, 2)
-        expect(raw).to.be.instanceof(BigNumber)
-        expect(raw.toString()).to.equal('12300')
-      })
-    })
-
-    describe('#calcValue()', () => {
-      it('should return value for number', () => {
-        const value = tl.utils.calcValue(numValue, 2)
-        expect(value).to.be.instanceof(BigNumber)
-        expect(value.toString()).to.equal('1.23')
-      })
-
-      it('should return value for string', () => {
-        const value = tl.utils.calcValue(strValue, 2)
-        expect(value).to.be.instanceof(BigNumber)
-        expect(value.toString()).to.equal('1.23')
-      })
-
-      it('should return value for BigNumber', () => {
-        const value = tl.utils.calcValue(bnValue, 2)
-        expect(value).to.be.instanceof(BigNumber)
-        expect(value.toString()).to.equal('1.23')
-      })
-    })
-
-    describe('#formatToAmount()', () => {
-      it('should format number to Amount object', () => {
-        const amount = tl.utils.formatToAmount(numValue, decimals)
-        expect(amount).to.have.keys('decimals', 'raw', 'value')
-        expect(amount.decimals).to.equal(2)
-        expect(amount.raw).to.equal('123')
-        expect(amount.value).to.equal('1.23')
-      })
-
-      it('should format string to Amount object', () => {
-        const amount = tl.utils.formatToAmount(strValue, decimals)
-        expect(amount).to.have.keys('decimals', 'raw', 'value')
-        expect(amount.decimals).to.equal(2)
-        expect(amount.raw).to.equal('123')
-        expect(amount.value).to.equal('1.23')
-      })
-
-      it('should format BigNumber to Amount object', () => {
-        const amount = tl.utils.formatToAmount(bnValue, decimals)
-        expect(amount).to.have.keys('decimals', 'raw', 'value')
-        expect(amount.decimals).to.equal(2)
-        expect(amount.raw).to.equal('123')
-        expect(amount.value).to.equal('1.23')
-      })
-    })
-
-    describe('#formatToAmountInternal()', () => {
-      it('should format number to AmountInternal object', () => {
-        const amount = tl.utils.formatToAmountInternal(numValue, decimals)
-        expect(amount).to.have.keys('decimals', 'raw', 'value')
-        expect(amount.decimals).to.equal(2)
-        expect(amount.raw).to.be.instanceof(BigNumber)
-        expect(amount.raw.toString()).to.equal('123')
-        expect(amount.value).to.be.instanceof(BigNumber)
-        expect(amount.value.toString()).to.equal('1.23')
-      })
-
-      it('should format string to Amount object', () => {
-        const amount = tl.utils.formatToAmountInternal(strValue, decimals)
-        expect(amount).to.have.keys('decimals', 'raw', 'value')
-        expect(amount.decimals).to.equal(2)
-        expect(amount.raw).to.be.instanceof(BigNumber)
-        expect(amount.raw.toString()).to.equal('123')
-        expect(amount.value).to.be.instanceof(BigNumber)
-        expect(amount.value.toString()).to.equal('1.23')
-      })
-
-      it('should format BigNumber to Amount object', () => {
-        const amount = tl.utils.formatToAmountInternal(bnValue, decimals)
-        expect(amount).to.have.keys('decimals', 'raw', 'value')
-        expect(amount.decimals).to.equal(2)
-        expect(amount.raw).to.be.instanceof(BigNumber)
-        expect(amount.raw.toString()).to.equal('123')
-        expect(amount.value).to.be.instanceof(BigNumber)
-        expect(amount.value.toString()).to.equal('1.23')
-      })
-    })
-
-    describe('#convertToAmount()', () => {
-      const amountInternal = tl.utils.formatToAmountInternal(123, 2)
-
-      it('should convert AmountInternal to Amount object', () => {
-        const amount = tl.utils.convertToAmount(amountInternal)
-        expect(amount).to.have.keys('decimals', 'raw', 'value')
-        expect(amount.decimals).to.equal(2)
-        expect(amount.raw).to.equal('123')
-        expect(amount.value).to.equal('1.23')
-      })
-    })
-
-    describe('#convertEthToWei()', () => {
-      it('should return 1 eth in wei', () => {
-        expect(tl.utils.convertEthToWei(1)).to.equal(1000000000000000000)
-      })
-
-      it('should return 0.123456789 eth in wei', () => {
-        expect(tl.utils.convertEthToWei(0.123456789)).to.equal(
-          123456789000000000
-        )
-      })
-
-      it('should return 1 wei', () => {
-        expect(tl.utils.convertEthToWei(0.000000000000000001)).to.equal(1)
+        await assert.isRejected(utils.fetchUrl('fake/endpoint'))
       })
     })
 
     describe('#buildUrl()', () => {
-      it('should return base url', () => {
+      beforeEach(() => {
+        fakeConfiguration = new FakeConfiguration()
+        utils = new Utils(fakeConfiguration)
+      })
+
+      it('should only return base url', () => {
         const base = 'http://trustlines.network/v1'
-        expect(tl.utils.buildUrl(base)).to.equal('http://trustlines.network/v1')
+        assert.equal(utils.buildUrl(base), 'http://trustlines.network/v1')
       })
 
       it('should return query url with encoded params', () => {
@@ -155,41 +69,340 @@ describe('unit', () => {
           key3: '?'
         }
         const queryUrl = '/path?key1=value1&key2=%20&key3=%3F'
-        expect(tl.utils.buildUrl(base, params)).to.equal(queryUrl)
+        assert.equal(utils.buildUrl(base, params), queryUrl)
       })
 
       it('should return url with encoded path', () => {
         const base = 'http://trustlines.network/v1'
+        const params = ['contact', '0x00', 'username with spaces']
         const url =
           'http://trustlines.network/v1/contact/0x00/username%20with%20spaces'
-        expect(
-          tl.utils.buildUrl(base, ['contact', '0x00', 'username with spaces'])
-        ).to.equal(url)
+        assert.equal(utils.buildUrl(base, params), url)
+      })
+    })
+
+    describe('#createLink()', () => {
+      beforeEach(() => {
+        fakeConfiguration = new FakeConfiguration()
+        utils = new Utils(fakeConfiguration)
+      })
+
+      it('should return url in trustlines link schema', () => {
+        const params = ['contact', '0x']
+        const url = 'http://trustlines.network/v1/contact/0x'
+        assert.equal(utils.createLink(params), url)
+      })
+    })
+
+    describe('#calcRaw()', () => {
+      beforeEach(() => {
+        fakeConfiguration = new FakeConfiguration()
+        utils = new Utils(fakeConfiguration)
+      })
+
+      it('should return raw value for number', () => {
+        const raw = utils.calcRaw(VALUE_NUM_INPUT, DECIMALS)
+        assert.instanceOf(raw, BigNumber)
+        assert.equal(raw.toString(), RAW_OUTPUT)
+      })
+
+      it('should return raw value for string', () => {
+        const raw = utils.calcRaw(VALUE_STR_INPUT, DECIMALS)
+        assert.instanceOf(raw, BigNumber)
+        assert.equal(raw.toString(), RAW_OUTPUT)
+      })
+
+      it('should return raw value for BigNumber', () => {
+        const raw = utils.calcRaw(VALUE_BN_INPUT, DECIMALS)
+        assert.instanceOf(raw, BigNumber)
+        assert.equal(raw.toString(), RAW_OUTPUT)
+      })
+    })
+
+    describe('#calcValue()', () => {
+      beforeEach(() => {
+        fakeConfiguration = new FakeConfiguration()
+        utils = new Utils(fakeConfiguration)
+      })
+
+      it('should return value for number', () => {
+        const value = utils.calcValue(RAW_NUM_INPUT, DECIMALS)
+        assert.instanceOf(value, BigNumber)
+        assert.equal(value.toString(), VALUE_OUTPUT)
+      })
+
+      it('should return value for string', () => {
+        const value = utils.calcValue(RAW_STR_INPUT, DECIMALS)
+        assert.instanceOf(value, BigNumber)
+        assert.equal(value.toString(), VALUE_OUTPUT)
+      })
+
+      it('should return value for BigNumber', () => {
+        const value = utils.calcValue(RAW_BN_INPUT, DECIMALS)
+        assert.instanceOf(value, BigNumber)
+        assert.equal(value.toString(), VALUE_OUTPUT)
+      })
+    })
+
+    describe('#formatToAmountInternal()', () => {
+      beforeEach(() => {
+        fakeConfiguration = new FakeConfiguration()
+        utils = new Utils(fakeConfiguration)
+      })
+
+      it('should format number to AmountInternal object', () => {
+        const amount = utils.formatToAmountInternal(RAW_NUM_INPUT, DECIMALS)
+        assert.hasAllKeys(amount, ['decimals', 'raw', 'value'])
+        assert.equal(amount.decimals, DECIMALS)
+        assert.instanceOf(amount.raw, BigNumber)
+        assert.equal(amount.raw.toString(), RAW_OUTPUT)
+        assert.instanceOf(amount.value, BigNumber)
+        assert.equal(amount.value.toString(), VALUE_OUTPUT)
+      })
+
+      it('should format string to Amount object', () => {
+        const amount = utils.formatToAmountInternal(RAW_STR_INPUT, DECIMALS)
+        assert.hasAllKeys(amount, ['decimals', 'raw', 'value'])
+        assert.equal(amount.decimals, DECIMALS)
+        assert.instanceOf(amount.raw, BigNumber)
+        assert.equal(amount.raw.toString(), RAW_OUTPUT)
+        assert.instanceOf(amount.value, BigNumber)
+        assert.equal(amount.value.toString(), VALUE_OUTPUT)
+      })
+
+      it('should format BigNumber to Amount object', () => {
+        const amount = utils.formatToAmountInternal(RAW_BN_INPUT, DECIMALS)
+        assert.hasAllKeys(amount, ['decimals', 'raw', 'value'])
+        assert.equal(amount.decimals, DECIMALS)
+        assert.instanceOf(amount.raw, BigNumber)
+        assert.equal(amount.raw.toString(), RAW_OUTPUT)
+        assert.instanceOf(amount.value, BigNumber)
+        assert.equal(amount.value.toString(), VALUE_OUTPUT)
+      })
+    })
+
+    describe('#formatToAmount()', () => {
+      beforeEach(() => {
+        fakeConfiguration = new FakeConfiguration()
+        utils = new Utils(fakeConfiguration)
+      })
+
+      it('should format number to Amount object', () => {
+        const amount = utils.formatToAmount(RAW_NUM_INPUT, DECIMALS)
+        assert.hasAllKeys(amount, ['decimals', 'raw', 'value'])
+        assert.equal(amount.decimals, DECIMALS)
+        assert.equal(amount.raw, RAW_OUTPUT)
+        assert.equal(amount.value, VALUE_OUTPUT)
+      })
+
+      it('should format string to Amount object', () => {
+        const amount = utils.formatToAmount(RAW_STR_INPUT, DECIMALS)
+        assert.hasAllKeys(amount, ['decimals', 'raw', 'value'])
+        assert.equal(amount.decimals, DECIMALS)
+        assert.equal(amount.raw, RAW_OUTPUT)
+        assert.equal(amount.value, VALUE_OUTPUT)
+      })
+
+      it('should format BigNumber to Amount object', () => {
+        const amount = utils.formatToAmount(RAW_BN_INPUT, DECIMALS)
+        assert.hasAllKeys(amount, ['decimals', 'raw', 'value'])
+        assert.equal(amount.decimals, DECIMALS)
+        assert.equal(amount.raw, RAW_OUTPUT)
+        assert.equal(amount.value, VALUE_OUTPUT)
+      })
+    })
+
+    describe('#convertToAmount()', () => {
+      beforeEach(() => {
+        fakeConfiguration = new FakeConfiguration()
+        utils = new Utils(fakeConfiguration)
+      })
+
+      it('should convert AmountInternal to Amount object', () => {
+        const amountInternal = utils.formatToAmountInternal(
+          RAW_NUM_INPUT,
+          DECIMALS
+        )
+        const amount = utils.convertToAmount(amountInternal)
+        assert.hasAllKeys(amount, ['decimals', 'raw', 'value'])
+        assert.equal(amount.decimals, DECIMALS)
+        assert.equal(amount.raw, RAW_OUTPUT)
+        assert.equal(amount.value, VALUE_OUTPUT)
+      })
+    })
+
+    describe('#formatEvent()', () => {
+      beforeEach(() => {
+        fakeConfiguration = new FakeConfiguration()
+        utils = new Utils(fakeConfiguration)
+      })
+
+      it('should format numerical values of event', () => {
+        const event = {
+          balance: 1000,
+          interestRateGiven: 500,
+          nonNumericAttr: 'hello'
+        }
+        const formattedEvent = utils.formatEvent(event, 2, 3)
+        assert.hasAllKeys(formattedEvent, [
+          'balance',
+          'interestRateGiven',
+          'nonNumericAttr'
+        ])
+        assert.equal(formattedEvent.balance.decimals, 2)
+        assert.equal(formattedEvent.balance.raw, '1000')
+        assert.equal(formattedEvent.balance.value, '10')
+        assert.equal(formattedEvent.interestRateGiven.decimals, 3)
+        assert.equal(formattedEvent.interestRateGiven.raw, '500')
+        assert.equal(formattedEvent.interestRateGiven.value, '0.5')
+        assert.equal(formattedEvent.nonNumericAttr, 'hello')
+      })
+    })
+
+    describe('#formatExchangeEvent()', () => {
+      beforeEach(() => {
+        fakeConfiguration = new FakeConfiguration()
+        utils = new Utils(fakeConfiguration)
+      })
+
+      it('should format numerical values of fill event', () => {
+        const rawFillEvent = {
+          filledMakerAmount: 100,
+          filledTakerAmount: 200,
+          type: 'LogFill'
+        }
+
+        const formattedFillEvent = utils.formatExchangeEvent(rawFillEvent)
+        assert.hasAllKeys(formattedFillEvent, [
+          'filledMakerAmount',
+          'filledTakerAmount',
+          'type'
+        ])
+        assert.hasAllKeys(formattedFillEvent.filledMakerAmount, [
+          'decimals',
+          'raw',
+          'value'
+        ])
+        assert.hasAllKeys(formattedFillEvent.filledTakerAmount, [
+          'decimals',
+          'raw',
+          'value'
+        ])
+      })
+
+      it('should format numerical values of cancel event', () => {
+        const rawFillEvent = {
+          cancelledMakerAmount: 100,
+          cancelledTakerAmount: 200,
+          type: 'LogCancel'
+        }
+
+        const formattedFillEvent = utils.formatExchangeEvent(rawFillEvent)
+        assert.hasAllKeys(formattedFillEvent, [
+          'cancelledMakerAmount',
+          'cancelledTakerAmount',
+          'type'
+        ])
+        assert.hasAllKeys(formattedFillEvent.cancelledMakerAmount, [
+          'decimals',
+          'raw',
+          'value'
+        ])
+        assert.hasAllKeys(formattedFillEvent.cancelledTakerAmount, [
+          'decimals',
+          'raw',
+          'value'
+        ])
+      })
+
+      it('should throw error', () => {
+        const noExchangeEvent = { type: 'NoExchange' }
+        assert.throw(() => utils.formatExchangeEvent(noExchangeEvent))
+      })
+    })
+
+    describe('#convertEthToWei()', () => {
+      beforeEach(() => {
+        fakeConfiguration = new FakeConfiguration()
+        utils = new Utils(fakeConfiguration)
+      })
+
+      it('should return 1 eth in wei', () => {
+        assert.equal(utils.convertEthToWei(1), 1000000000000000000)
+      })
+
+      it('should return 0.123456789 eth in wei', () => {
+        assert.equal(utils.convertEthToWei(0.123456789), 123456789000000000)
+      })
+
+      it('should return 1 wei', () => {
+        assert.equal(utils.convertEthToWei(0.000000000000000001), 1)
       })
     })
 
     describe('#convertToHexString()', () => {
-      const num = 123
-      const numDecStr = '123'
-      const numHexStr = '0x7b'
+      const NUM = 123
+      const NUM_HEX_STR = '0x7b'
+
+      beforeEach(() => {
+        fakeConfiguration = new FakeConfiguration()
+        utils = new Utils(fakeConfiguration)
+      })
 
       it('should convert decimal string to hex', () => {
-        const convertedHex = tl.utils.convertToHexString(numDecStr)
-        expect(convertedHex).to.equal('0x7b')
+        assert.equal(utils.convertToHexString(NUM.toString()), NUM_HEX_STR)
       })
 
       it('should convert hex string to hex', () => {
-        const convertedHex = tl.utils.convertToHexString(numHexStr)
-        expect(convertedHex).to.equal(numHexStr)
+        assert.equal(utils.convertToHexString(NUM_HEX_STR), NUM_HEX_STR)
       })
 
       it('should convert number to hex', () => {
-        const convertedHex = tl.utils.convertToHexString(num)
-        expect(convertedHex).to.equal('0x7b')
+        assert.equal(utils.convertToHexString(NUM), NUM_HEX_STR)
       })
 
       it('should throw on float', () => {
-        expect(() => tl.utils.convertToHexString(10.2)).to.throw()
+        assert.throw(() => utils.convertToHexString(1.23))
+      })
+    })
+
+    describe('#checkAddress()', () => {
+      const address = '0xf8E191d2cd72Ff35CB8F012685A29B31996614EA'
+      const lowerCaseAddress = address.toLowerCase()
+
+      beforeEach(() => {
+        fakeConfiguration = new FakeConfiguration()
+        utils = new Utils(fakeConfiguration)
+      })
+
+      it('should return true for lower case', () => {
+        assert.ok(utils.checkAddress(lowerCaseAddress))
+      })
+
+      it('should return false for lower case', () => {
+        assert.notOk(utils.checkAddress('0xabcdefgh'))
+      })
+
+      it('should return true for checksum', () => {
+        assert.ok(utils.checkAddress(address))
+      })
+
+      it('should return false for checksum', () => {
+        assert.notOk(utils.checkAddress('0xABCDEFGH'))
+      })
+    })
+
+    describe('#generateRandomNumber()', () => {
+      beforeEach(() => {
+        fakeConfiguration = new FakeConfiguration()
+        utils = new Utils(fakeConfiguration)
+      })
+
+      it('should generate a random number', () => {
+        const randomNumber = utils.generateRandomNumber(2)
+        assert.instanceOf(randomNumber, BigNumber)
+        assert.isAtMost(randomNumber.toNumber(), 99)
+        assert.isAtLeast(randomNumber.toNumber(), 10)
       })
     })
   })

--- a/tests/unit/Utils.test.ts
+++ b/tests/unit/Utils.test.ts
@@ -42,6 +42,16 @@ describe('unit', () => {
         assert.deepEqual(jsonResponse, fakeResponse)
       })
 
+      it('should return 200 json response for endpoint with slash', async () => {
+        const fakeResponse = { hello: 'world' }
+
+        // mock OK response
+        fetchMock.get('*', fakeResponse)
+
+        const jsonResponse = await utils.fetchUrl('/fake/endpoint')
+        assert.deepEqual(jsonResponse, fakeResponse)
+      })
+
       it('should throw error', async () => {
         // mock ERROR response
         fetchMock.get('*', 400)

--- a/yarn.lock
+++ b/yarn.lock
@@ -530,6 +530,21 @@ babel-code-frame@^6.22.0:
     esutils "^2.0.2"
     js-tokens "^3.0.2"
 
+babel-polyfill@^6.26.0:
+  version "6.26.0"
+  resolved "https://registry.yarnpkg.com/babel-polyfill/-/babel-polyfill-6.26.0.tgz#379937abc67d7895970adc621f284cd966cf2153"
+  dependencies:
+    babel-runtime "^6.26.0"
+    core-js "^2.5.0"
+    regenerator-runtime "^0.10.5"
+
+babel-runtime@^6.26.0:
+  version "6.26.0"
+  resolved "https://registry.yarnpkg.com/babel-runtime/-/babel-runtime-6.26.0.tgz#965c7058668e82b55d7bfe04ff2337bc8b5647fe"
+  dependencies:
+    core-js "^2.4.0"
+    regenerator-runtime "^0.11.0"
+
 balanced-match@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/balanced-match/-/balanced-match-1.0.0.tgz#89b4d199ab2bee49de164ea02b89ce462d71b767"
@@ -1136,6 +1151,10 @@ copy-concurrently@^1.0.0:
 copy-descriptor@^0.1.0:
   version "0.1.1"
   resolved "https://registry.yarnpkg.com/copy-descriptor/-/copy-descriptor-0.1.1.tgz#676f6eb3c39997c2ee1ac3a924fd6124748f578d"
+
+core-js@^2.4.0, core-js@^2.5.0:
+  version "2.6.0"
+  resolved "https://registry.yarnpkg.com/core-js/-/core-js-2.6.0.tgz#1e30793e9ee5782b307e37ffa22da0eacddd84d4"
 
 core-util-is@1.0.2, core-util-is@~1.0.0:
   version "1.0.2"
@@ -1928,6 +1947,15 @@ fd-slicer@~1.1.0:
   dependencies:
     pend "~1.2.0"
 
+fetch-mock@^7.2.5:
+  version "7.2.5"
+  resolved "https://registry.yarnpkg.com/fetch-mock/-/fetch-mock-7.2.5.tgz#4682f51b9fa74d790e10a471066cb22f3ff84d48"
+  dependencies:
+    babel-polyfill "^6.26.0"
+    glob-to-regexp "^0.4.0"
+    path-to-regexp "^2.2.1"
+    whatwg-url "^6.5.0"
+
 figgy-pudding@^3.1.0, figgy-pudding@^3.5.1:
   version "3.5.1"
   resolved "https://registry.yarnpkg.com/figgy-pudding/-/figgy-pudding-3.5.1.tgz#862470112901c727a0e495a80744bd5baa1d6790"
@@ -2203,6 +2231,10 @@ glob-parent@^3.1.0:
   dependencies:
     is-glob "^3.1.0"
     path-dirname "^1.0.0"
+
+glob-to-regexp@^0.4.0:
+  version "0.4.0"
+  resolved "https://registry.yarnpkg.com/glob-to-regexp/-/glob-to-regexp-0.4.0.tgz#49bd677b1671022bd10921c3788f23cdebf9c7e6"
 
 glob@7.1.2:
   version "7.1.2"
@@ -3066,6 +3098,10 @@ lodash.flattendeep@^4.4.0:
   version "4.4.0"
   resolved "https://registry.yarnpkg.com/lodash.flattendeep/-/lodash.flattendeep-4.4.0.tgz#fb030917f86a3134e5bc9bec0d69e0013ddfedb2"
 
+lodash.sortby@^4.7.0:
+  version "4.7.0"
+  resolved "https://registry.yarnpkg.com/lodash.sortby/-/lodash.sortby-4.7.0.tgz#edd14c824e2cc9c1e0b0a1b42bb5210516a42438"
+
 lodash@=4.17.4:
   version "4.17.4"
   resolved "http://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz#78203a4d1c328ae1d86dca6460e369b57f4055ae"
@@ -3841,6 +3877,10 @@ path-to-regexp@0.1.7:
   version "0.1.7"
   resolved "https://registry.yarnpkg.com/path-to-regexp/-/path-to-regexp-0.1.7.tgz#df604178005f522f15eb4490e7247a1bfaa67f8c"
 
+path-to-regexp@^2.2.1:
+  version "2.4.0"
+  resolved "https://registry.yarnpkg.com/path-to-regexp/-/path-to-regexp-2.4.0.tgz#35ce7f333d5616f1c1e1bfe266c3aba2e5b2e704"
+
 path-type@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/path-type/-/path-type-3.0.0.tgz#cef31dc8e0a1a3bb0d105c0cd97cf3bf47f4e36f"
@@ -4117,6 +4157,14 @@ rechoir@^0.6.2:
 reconnecting-websocket@^3.0.7:
   version "3.2.2"
   resolved "https://registry.yarnpkg.com/reconnecting-websocket/-/reconnecting-websocket-3.2.2.tgz#8097514e926e9855e03c39e76efa2e3d1f371bee"
+
+regenerator-runtime@^0.10.5:
+  version "0.10.5"
+  resolved "https://registry.yarnpkg.com/regenerator-runtime/-/regenerator-runtime-0.10.5.tgz#336c3efc1220adcedda2c9fab67b5a7955a33658"
+
+regenerator-runtime@^0.11.0:
+  version "0.11.1"
+  resolved "https://registry.yarnpkg.com/regenerator-runtime/-/regenerator-runtime-0.11.1.tgz#be05ad7f9bf7d22e056f9726cee5017fbf19e2e9"
 
 regex-not@^1.0.0, regex-not@^1.0.2:
   version "1.0.2"
@@ -4920,6 +4968,12 @@ tough-cookie@~2.4.3:
     psl "^1.1.24"
     punycode "^1.4.1"
 
+tr46@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/tr46/-/tr46-1.0.1.tgz#a8b13fd6bfd2489519674ccde55ba3693b706d09"
+  dependencies:
+    punycode "^2.1.0"
+
 trim-right@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/trim-right/-/trim-right-1.0.1.tgz#cb2e1203067e0c8de1f614094b9fe45704ea6003"
@@ -5484,6 +5538,10 @@ web3@^1.0.0-beta.34:
     web3-shh "1.0.0-beta.36"
     web3-utils "1.0.0-beta.36"
 
+webidl-conversions@^4.0.2:
+  version "4.0.2"
+  resolved "https://registry.yarnpkg.com/webidl-conversions/-/webidl-conversions-4.0.2.tgz#a855980b1f0b6b359ba1d5d9fb39ae941faa63ad"
+
 webpack-cli@^3.0.8:
   version "3.1.2"
   resolved "https://registry.yarnpkg.com/webpack-cli/-/webpack-cli-3.1.2.tgz#17d7e01b77f89f884a2bbf9db545f0f6a648e746"
@@ -5556,6 +5614,14 @@ webpack@^4.16.0:
 whatwg-fetch@>=0.10.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/whatwg-fetch/-/whatwg-fetch-3.0.0.tgz#fc804e458cc460009b1a2b966bc8817d2578aefb"
+
+whatwg-url@^6.5.0:
+  version "6.5.0"
+  resolved "https://registry.yarnpkg.com/whatwg-url/-/whatwg-url-6.5.0.tgz#f2df02bff176fd65070df74ad5ccbb5a199965a8"
+  dependencies:
+    lodash.sortby "^4.7.0"
+    tr46 "^1.0.1"
+    webidl-conversions "^4.0.2"
 
 which-module@^2.0.0:
   version "2.0.0"


### PR DESCRIPTION
Add unit tests for classes `Configuration` and `Utils`. Includes also a small fix for URL formatting/handling. The `apiUrl` for example was created with an ending `/` which is removed in this PR. Also endpoint parameters can now be given as `endpoint` or `/endpoint`.