### PR TITLE
Fix filters in deploy job for latest version

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -163,8 +163,9 @@ workflows:
     jobs:
       - lint
       - build:
-          requires:
-            - lint
+          filters:
+            tags:
+              only: /.*/
       - unit-test:
           requires:
             - build
@@ -186,11 +187,9 @@ workflows:
       - deploy-latest:
           context: npm-credentials
           requires:
-            - unit-test
-            - integration-test
-            - e2e-test
+            - build
           filters:
             branches:
-              only: develop
+              ignore: /.*/
             tags:
               only: /^v.*/


### PR DESCRIPTION
The deploy job for `latest` was configured wrongly. It started even though no git tag was published.