### PR TITLE
Feature/e2e image

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -82,6 +82,52 @@ jobs:
       - run-code-coverage:
           flag: integration
 
+  build-e2e-image:
+    <<: *defaults
+    environment:
+      DOCKER_REPO: trustlines/e2e
+      LOCAL_IMAGE: e2e
+    steps:
+      - setup_remote_docker
+      - checkout
+      - run:
+          name: Build docker image
+          command: |
+            docker build . -t $LOCAL_IMAGE
+      - run:
+          name: Save docker image
+          command: |
+            mkdir -p ~/images
+            docker save --output ~/images/$LOCAL_IMAGE.tar $LOCAL_IMAGE
+      - persist_to_workspace:
+          root: "~"
+          paths:
+            - images
+
+  deploy-docker-image:
+    <<: *defaults
+    environment:
+      DOCKER_REPO: trustlines/e2e
+      LOCAL_IMAGE: e2e
+    working_directory: ~/repo
+    steps:
+      - setup_remote_docker
+      - attach_workspace:
+          at: '~'
+      - run:
+          name: Load docker image
+          command: |
+            docker load --input ~/images/$LOCAL_IMAGE.tar
+      - run:
+          name: Login to dockerhub
+          command: |
+            echo "$DOCKER_PASSWORD" | docker login -u "$DOCKER_USER" --password-stdin
+      - run:
+          name: Upload latest
+          command: |
+            docker tag $LOCAL_IMAGE $DOCKER_REPO:latest
+            docker push $DOCKER_REPO:latest
+
   e2e-test:
     machine: true
     working_directory: ~/repo
@@ -190,3 +236,11 @@ workflows:
               ignore: /.*/
             tags:
               only: /^v.*/
+
+  e2e-image:
+    jobs:
+      - build-e2e-image
+      - deploy-docker-image:
+          context: docker-credentials
+          requires:
+            - build-e2e-image

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,13 @@
+#
+# you can build the image with:
+#
+#   docker build . -t e2e
+
+FROM node:10-jessie
+RUN npm install -g yarn
+
+COPY . clientlib
+WORKDIR clientlib
+RUN yarn install --frozen-lockfile
+ENV RELAY_HOSTNAME relay
+CMD ["yarn", "test:e2e"]

--- a/tests/Fixtures.ts
+++ b/tests/Fixtures.ts
@@ -8,7 +8,7 @@ export const keystore3 =
   '{"encSeed":{"encStr":"eEM0n29iCxQIm67Xt5XQseVllcfNEX1PTV5COHBxaUlmyOASd8jmTRjB1ruItlUqB0+T758EQz1oCgRfW6oluGI2SEF5liaNf4ku2wqpgMMJX3xKhiCQ4oeSEAM/SfmZ/TQ4S+14crRgsZxS8fDdu2G8uOT6DWJ3LpOY3aKW34BIA5YepfjrFg==","nonce":"Wsc2oXdrXX/LSbZ4n6pciSHd+MPJ5eeN"},"encHdRootPriv":{"encStr":"qHQ6BXF6SZoku0++cPMfG3/cOmqR+Zzk95CCk0vnMUluvbIaqEK+wN4Sc0trcnUmIOoOtFrO15lgJETMcjB/nHBLAmSdeVH92rLBB5GIMA2AHXf4GYXETgl/Z8rq6Rm3GvqLFKwghewFspvgV5Ykjritd7/yajxsSKye7DcW1Q==","nonce":"9MfuGFodFQP9fmD3+OUz9oKCURDd16r/"},"addresses":["c7d6401b81a2f70c5906e8a6fbebe680c69fa03d"],"encPrivKeys":{"c7d6401b81a2f70c5906e8a6fbebe680c69fa03d":{"key":"nrum/qp+I6oF+AypB/6xVDdbmH7S4plVf3VxSCmRwiz8rF3HDyLwafYh3Hur4foC","nonce":"/HC96G1H5OCXCJSPN5Z5Rq4++3d1C+TO"}},"hdPathString":"m/44\'/60\'/0\'/0","salt":"pXfIg1o/mPRVUwiXBkYnl0WpJfu4oRqi61rjZx1SfNY=","hdIndex":1,"version":3}'
 
 export const config = {
-  host: 'localhost',
+  host: process.env.RELAY_HOSTNAME || 'localhost',
   path: 'api/v1/',
   port: 5000,
   protocol: 'http'


### PR DESCRIPTION
build and upload trustlines/e2e image, which is being used/will be used by the end2end repo to run end2end tests for the relay server, py-eth-index and the contracts.
implements #174