### PR TITLE
Change one tslint config

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "build": "tsc && tsc -m es6 --outDir lib-esm && webpack",
     "build:esm": "tsc -m es6 --outDir lib-esm",
     "doc": "typedoc --options tdconfig.json",
-    "lint": "tslint -c tslint.json ./src/**/**.ts ./tests/**/**.ts",
+    "lint": "tslint -c tslint.json './src/**/**.ts' './tests/**/**.ts'",
     "prettier": "prettier --write './{src,tests}/**/*.ts'",
     "prettier:check": "prettier --check './{src,tests}/**/*.ts'",
     "prettier:big-tabs": "prettier --write --print-width 120 --no-semi --single-quote --tab-width 4  './{src,tests}/**/*.ts'",

--- a/tslint.json
+++ b/tslint.json
@@ -4,6 +4,7 @@
     "interface-name": [true, "never-prefix"],
     "no-submodule-imports": false,
     "no-console": false,
-    "no-implicit-dependencies": false
+    "no-implicit-dependencies": false,
+    "object-literal-sort-keys": false
   }
 }


### PR DESCRIPTION
remove this rule from our tslint config: https://palantir.github.io/tslint/rules/object-literal-sort-keys/

The first rationale is that this rule is sometimes not enforced and sometimes it is, making the code inconsistent.

The second rationale is that `tslint --fix` will not fix this by reordering the keys in the object literal like it does for the import.

The third rationale is that it makes the code less readable in certain places: I believe most are used to read objects like `{ source: 'a', destination: 'b' }` rather than `{ destination: 'b', source: 'a' }` for a transaction from a to b, for example.

Also adds comas to the `yarn lint` command because it was not running on every source files otherwise.