### PR TITLE
Fix/wallet signer confusion

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,6 +28,10 @@
     "*.{ts,js,json,css,md}": [
       "prettier --write",
       "git add"
+    ],
+    "*.ts": [
+      "tslint -c tslint.json --fix",
+      "git add"
     ]
   },
   "nyc": {

--- a/src/TLNetwork.ts
+++ b/src/TLNetwork.ts
@@ -182,8 +182,8 @@ export class TLNetwork {
     this.provider = provider
   }
 
-  public setSigner(web3Provider, wallet): void {
-    const signer = web3Provider
+  public setSigner(web3Provider, wallet: TLWallet): void {
+    const signer: TLSigner = web3Provider
       ? new Web3Signer(new ethers.providers.Web3Provider(web3Provider))
       : wallet
 

--- a/src/signers/TLSigner.ts
+++ b/src/signers/TLSigner.ts
@@ -1,10 +1,4 @@
-import {
-  Amount,
-  MetaTransaction,
-  RawTxObject,
-  Signature,
-  TxInfos
-} from '../typings'
+import { Amount, RawTxObject, Signature, TxInfos } from '../typings'
 
 /**
  * Interface for different signer strategies.

--- a/src/wallets/EthersWallet.ts
+++ b/src/wallets/EthersWallet.ts
@@ -2,7 +2,6 @@ import { BigNumber } from 'bignumber.js'
 import { ethers } from 'ethers'
 
 import { TLProvider } from '../providers/TLProvider'
-import { TLSigner } from '../signers/TLSigner'
 import { TL_WALLET_VERSION, TLWallet, WALLET_TYPE_ETHERS } from './TLWallet'
 
 import utils from '../utils'
@@ -19,7 +18,7 @@ import {
 /**
  * The EthersWallet class contains wallet related methods.
  */
-export class EthersWallet implements TLWallet, TLSigner {
+export class EthersWallet implements TLWallet {
   public provider: TLProvider
 
   private wallet: ethers.Wallet

--- a/src/wallets/IdentityWallet.ts
+++ b/src/wallets/IdentityWallet.ts
@@ -15,10 +15,9 @@ import {
 } from '../typings'
 
 import { joinSignature, SigningKey } from 'ethers/utils'
-import { TLSigner } from '../signers/TLSigner'
 import utils from '../utils'
 
-export class IdentityWallet implements TLWallet, TLSigner {
+export class IdentityWallet implements TLWallet {
   public provider: TLProvider
 
   private wallet: ethers.Wallet

--- a/src/wallets/TLWallet.ts
+++ b/src/wallets/TLWallet.ts
@@ -1,9 +1,10 @@
 import { UserObject } from '../typings'
+import { TLSigner } from '../signers/TLSigner'
 
 /**
  * Interface for different wallet strategies.
  */
-export interface TLWallet {
+export interface TLWallet extends TLSigner {
   address: string
   pubKey: string
   showSeed(): Promise<string>

--- a/src/wallets/TLWallet.ts
+++ b/src/wallets/TLWallet.ts
@@ -1,5 +1,5 @@
-import { UserObject } from '../typings'
 import { TLSigner } from '../signers/TLSigner'
+import { UserObject } from '../typings'
 
 /**
  * Interface for different wallet strategies.

--- a/tests/helpers/FakeTLWallet.ts
+++ b/tests/helpers/FakeTLWallet.ts
@@ -8,11 +8,12 @@ import {
   FAKE_PRIVATE_KEY,
   FAKE_SEED
 } from '../Fixtures'
+import { FakeTLSigner } from './FakeTLSigner'
 
 /**
  * Mock TxSigner interface
  */
-export class FakeTLWallet implements TLWallet {
+export class FakeTLWallet extends FakeTLSigner implements TLWallet {
   public address: string = '0xf8E191d2cd72Ff35CB8F012685A29B31996614EA'
   public pubKey: string =
     'a5da0d9516c483883256949c3cac6ed73e4eb50ca85f7bdc2f360bbbf9e2d472'
@@ -20,7 +21,7 @@ export class FakeTLWallet implements TLWallet {
   public errors
 
   constructor() {
-    this.errors = []
+    super()
   }
 
   public createAccount(): Promise<UserObject> {


### PR DESCRIPTION
Change `TLWallet` interface to extend `TLSigner` since we were using wallets as signers and they are.
closes https://github.com/trustlines-network/clientlib/issues/205

Also adds `tsling --fix` to pre-commit hooks because I had a linting error on circle.